### PR TITLE
Fix bug where file indent size text was not restored

### DIFF
--- a/src/Extension/Options/OptionsPage.cs
+++ b/src/Extension/Options/OptionsPage.cs
@@ -65,6 +65,7 @@ namespace IndentRainbow.Extension.Options
             OptionsManager.LoadSettings();
             IndentSize = OptionsManager.indentSize.Get();
             Colors = OptionsManager.colors.Get();
+            FileSpecificIndentSizes = OptionsManager.fileExtensionsString.Get();
             OpacityMultiplier = OptionsManager.opacityMultiplier.Get();
             HighglightErrors = OptionsManager.detectErrors.Get();
             ErrorColor = OptionsManager.errorColor.Get();

--- a/src/Extension/source.extension.vsixmanifest
+++ b/src/Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241" Version="0.5.0.1" Language="en-US" Publisher="Marcel Wagner" />
+        <Identity Id="IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241" Version="0.5.1" Language="en-US" Publisher="Marcel Wagner" />
         <DisplayName>IndentRainbow</DisplayName>
         <Description xml:space="preserve">Extensions for showing rainbow colors to make it easier to differentiate indent levels.</Description>
     </Metadata>


### PR DESCRIPTION
When file specific intend sizes were specified, upon restarting Visual Studio, those setting was not displayed anymore (but still respected). This PR fixes this.