### PR TITLE
Fix issue where general opacity didn't work on gradient colors

### DIFF
--- a/src/IndentRainbow.Extension/source.extension.vsixmanifest
+++ b/src/IndentRainbow.Extension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241" Version="1.1.0" Language="en-US" Publisher="Marcel Wagner" />
+        <Identity Id="IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241" Version="1.1.1" Language="en-US" Publisher="Marcel Wagner" />
         <DisplayName>IndentRainbow</DisplayName>
         <Description xml:space="preserve">Extensions for showing rainbow colors to make it easier to differentiate indent levels.</Description>
         <Icon>Resources\IndentRainbowPackage.ico</Icon>

--- a/src/IndentRainbow.Logic/Parser/ColorParser.cs
+++ b/src/IndentRainbow.Logic/Parser/ColorParser.cs
@@ -22,48 +22,37 @@ namespace IndentRainbow.Logic.Parser
             var colorCount = splitColors.Length;
             var brushes = new List<Brush>();
 
-            List<Color> c = new List<Color>();
+            List<Color> colorList = new List<Color>();
 
             for (var i = 0; i < colorCount; i++)
             {
                 try
                 {
-                    c.Add((Color)ColorConverter.ConvertFromString(splitColors[i]));
+                    var color = (Color)ColorConverter.ConvertFromString(splitColors[i]);
+                    color.A = (byte)Math.Floor(color.A * opacityMultiplier);
+                    colorList.Add(color);
                 }
                 catch (FormatException) { }
             }
 
-            for (var i = 0; i < c.Count; i++)
+            for (var i = 0; i < colorList.Count; i++)
             {
                 Brush brush;
                 if (colorMode == 1)
                 {
                     if (i + 1 < colorCount)
                     {
-                        brush = new LinearGradientBrush(c[i], c[i + 1], 0.0);
+                        brush = new LinearGradientBrush(colorList[i], colorList[i + 1], 0.0);
                     }
                     else
                     {
-                        brush = new LinearGradientBrush(c[i], c[0], 0.0);
+                        brush = new LinearGradientBrush(colorList[i], colorList[0], 0.0);
                     }
                 }
                 else
                 {
-                    brush = new SolidColorBrush(c[i]);
+                    brush = new SolidColorBrush(colorList[i]);
                 }
-
-                double alphaOfBrush = c[i].A;
-                var color = c[i];
-                color.A = (byte)Math.Floor(alphaOfBrush * opacityMultiplier);
-                if (colorMode == 1)
-                {
-                    brush.Opacity = color.A;
-                }
-                else
-                {
-                    ((SolidColorBrush)brush).Color = color;
-                }
-
                 brushes.Add(brush);
             }
             return brushes.ToArray();


### PR DESCRIPTION
It seems that LinearGradientBrush seems to ignore the opacity property (to a degree). Fix for this is to apply the opacity to the colors instead of setting it to the brushes.

Fixes #20 