### PR TITLE
Fix bug where certain file extensions couldn't be determined

### DIFF
--- a/src/IndentRainbow.Extension/Classification/Indent.cs
+++ b/src/IndentRainbow.Extension/Classification/Indent.cs
@@ -3,9 +3,11 @@ using IndentRainbow.Extension.Options;
 using IndentRainbow.Logic.Classification;
 using IndentRainbow.Logic.Colors;
 using IndentRainbow.Logic.Drawing;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
+using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace IndentRainbow.Extension
 {
@@ -68,10 +70,9 @@ namespace IndentRainbow.Extension
             );
 
 
-            bool result = textDocumentFactory.TryGetTextDocument(this.view.TextBuffer, out ITextDocument textDocument);
-            if (result)
+            string filePath = GetPath(view);
+            if(filePath != null)
             {
-                string filePath = textDocument.FilePath;
                 var filePathSplit = filePath.Split('.');
                 var extension = filePathSplit[filePathSplit.Length - 1];
                 if (OptionsManager.fileExtensionsDictionary.Get().ContainsKey(extension))
@@ -127,6 +128,18 @@ namespace IndentRainbow.Extension
 
             string text = line.Snapshot.GetText();
             decorator.DecorateLine(text, start, end);
+        }
+
+        private static string GetPath(IWpfTextView textView)
+        {
+            textView.TextBuffer.Properties.TryGetProperty(typeof(IVsTextBuffer), out IVsTextBuffer bufferAdapter);
+
+            if (!(bufferAdapter is IPersistFileFormat persistFileFormat))
+            {
+                return null;
+            }
+            persistFileFormat.GetCurFile(out string filePath, out _);
+            return filePath;
         }
     }
 }

--- a/src/IndentRainbow.Extension/IndentRainbow.Extension.csproj
+++ b/src/IndentRainbow.Extension/IndentRainbow.Extension.csproj
@@ -116,7 +116,7 @@
       <Version>15.0.26201</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0">
-      <Version>17.0.0-previews-1-31410-258</Version>
+      <Version>16.7.30328.74</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Text.Data">
       <Version>15.0.26201</Version>

--- a/src/IndentRainbow.Extension/source.extension.vsixmanifest
+++ b/src/IndentRainbow.Extension/source.extension.vsixmanifest
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241" Version="1.2.1" Language="en-US" Publisher="Marcel Wagner" />
+        <Identity Id="IndentRainbow.f05146ed-8025-4668-b7b1-8a74bd22b241" Version="1.2.2" Language="en-US" Publisher="Marcel Wagner" />
         <DisplayName>IndentRainbow</DisplayName>
         <Description xml:space="preserve">Extensions for showing rainbow colors to make it easier to differentiate indent levels.</Description>
         <Icon>Resources\IndentRainbowPackage.ico</Icon>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)">
-          <ProductArchitecture>x86</ProductArchitecture>
+            <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
-          <ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,17.0)">
-          <ProductArchitecture>x86</ProductArchitecture>
+            <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,)">
-          <ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[15.0,17.0)">
-          <ProductArchitecture>x86</ProductArchitecture>
+            <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.0,)">
-          <ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
     <Dependencies>


### PR DESCRIPTION
The previous code used to get the file extension of an opened document could fail for certain files as mentioned here: https://stackoverflow.com/questions/48068134/get-path-of-the-document-from-iwpftextview-for-non-cs-files

Using different code for this, we no longer have this issue. Closes #24 